### PR TITLE
Pick IP or Hostname from ingress (AWS Compatibility)

### DIFF
--- a/kubernetes/kubeclient.go
+++ b/kubernetes/kubeclient.go
@@ -738,6 +738,10 @@ func GetServiceExternalIP(clientset *kubernetes.Clientset, ns string, name strin
 			if ip != "" {
 				return nil
 			}
+			ip = ingress[0].Hostname
+			if ip != "" {
+				return nil
+			}
 		}
 		return errors.New("IP is not available yet.")
 	}


### PR DESCRIPTION
When the service type is `LoadBalancer`, k8s creates AWS ELB and sets hostname, instead of IP