### PR TITLE
Lam 402/use access token

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -240,6 +240,7 @@ func (s *RestClient) getAccessToken() string {
 		if time.Now().Unix() < timeout-10 {
 			if timeout > latest {
 				activeToken = token
+				latest = timeout
 			}
 		}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -245,16 +245,16 @@ func (s *RestClient) getAccessToken() string {
 	}
 	if activeToken == "" {
 		logging.Info("Access token is expired - refreshing...")
-		token, error := s.RefreshTokens()
+		_, accessToken, error := s.RefreshTokens()
 		if error == nil {
-			return token
+			return accessToken
 		}
 		logging.Error("Refresh Token Error: %v\n", error)
 	}
 	return activeToken
 }
 
-func (s *RestClient) parseTokenResponse(resp *authSuccess) string {
+func (s *RestClient) parseTokenResponse(resp *authSuccess) (string, string) {
 	token := resp.AccessToken
 	s.RefreshToken = resp.RefreshToken
 	expiresIn := resp.ExpiresIn
@@ -262,12 +262,13 @@ func (s *RestClient) parseTokenResponse(resp *authSuccess) string {
 		expirationTime := time.Now().Unix() + expiresIn
 		(*s.TokenStore).Store(token, expirationTime)
 	}
-	return s.RefreshToken
+	return s.RefreshToken, token
 }
 
-func (s *RestClient) auth(body string) (string, error) {
+func (s *RestClient) auth(body string) (refreshToken string, accessToken string, err error) {
 	url := s.URL + "/oauth/access_token"
-	resp, err := resty.R().
+	var resp *resty.Response
+	resp, err = resty.R().
 		SetHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8").
 		SetHeader("Accept", "application/json").
 		SetBody([]byte(body)).
@@ -276,29 +277,29 @@ func (s *RestClient) auth(body string) (string, error) {
 		Post(url)
 
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	if resp != nil {
 		if resp.IsError() {
-			return "", errors.New(string(resp.Body()))
+			return "", "", errors.New(string(resp.Body()))
 		}
 		(*s.TokenStore).Clean()
-		refreshToken := s.parseTokenResponse(resp.Result().(*authSuccess))
-		return refreshToken, nil
+		refreshToken, accessToken := s.parseTokenResponse(resp.Result().(*authSuccess))
+		return refreshToken, accessToken, nil
 	}
 
-	return "", errors.New("Authentication failed")
+	return "", "", errors.New("Authentication failed")
 }
 
-func (s *RestClient) Login(username string, password string) (string, error) {
+func (s *RestClient) Login(username string, password string) (refreshToken string, accessToken string, err error) {
 	s.Username = username
 	s.Password = password
 	body := "username=" + username + "&password=" + password + "&client_id=frontend&client_secret=&grant_type=password"
 	return s.auth(body)
 }
 
-func (s *RestClient) RefreshTokens() (string, error) {
+func (s *RestClient) RefreshTokens() (refreshToken string, accessToken string, err error) {
 	body := "client_id=frontend&client_secret=&grant_type=refresh_token&refresh_token=" + s.RefreshToken
 	return s.auth(body)
 }
@@ -308,7 +309,7 @@ func (s *RestClient) fallbackToRefreshToken(f func() (*resty.Response, error)) (
 	if err == nil && resp.IsError() {
 		if resp.StatusCode() == http.StatusUnauthorized {
 			logging.Info("Got StatusUnauthorized: ( %v ), refreshing token...", http.StatusUnauthorized)
-			if _, refreshTokensErr := s.RefreshTokens(); refreshTokensErr != nil {
+			if _, _, refreshTokensErr := s.RefreshTokens(); refreshTokensErr != nil {
 				logging.Error("Cannot refresh token - %v\n", refreshTokensErr)
 				return nil, refreshTokensErr
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -42,7 +42,7 @@ func TestClientAuthToken(t *testing.T) {
 			switch r.URL.Path {
 			case "/oauth/access_token":
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"token_type": "Bearer","access_token": "Test-Access-Token","expires_in": 3599,"refresh_token": "Test-Access-Token"}`))
+				_, _ = w.Write([]byte(`{"token_type": "Bearer","access_token": "Test-Access-Token","expires_in": 3599,"refresh_token": "Test-Refresh-Token"}`))
 			default:
 				t.Logf("Unhandled Path: %v", r.URL.Path)
 			}
@@ -56,10 +56,10 @@ func TestClientAuthToken(t *testing.T) {
 	Password := "pass"
 	Version := "v1"
 	restClient := client.NewRestClient(ts.URL, Token, Version, logging.Verbose, Cert, nil)
-	token, err := restClient.Login(Username, Password)
+	refreshToken, _, err := restClient.Login(Username, Password)
 
 	assertError(t, err)
-	assertEqual(t, "Test-Access-Token", token)
+	assertEqual(t, "Test-Refresh-Token", refreshToken)
 }
 
 func TestClientListErrorMessage(t *testing.T) {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -66,12 +66,12 @@ var addCmd = &cobra.Command{
 			}
 			fmt.Printf("User created.\n")
 			restClientForAddedUser := client.NewRestClient(Config.Url, "", Config.APIVersion, logging.Verbose, Config.Cert, nil)
-			token, loginError := restClientForAddedUser.Login(Username, temporarayPassword)
+			refreshToken, _, loginError := restClientForAddedUser.Login(Username, temporarayPassword)
 			if loginError != nil {
 				return loginError
 			}
 			fmt.Printf("User can login with:\n")
-			fmt.Printf("%v login --url %v --user %v --initial --token %v --cert <<EOF \"%v\"\nEOF\n", AppName, Config.Url, Username, token, Config.Cert)
+			fmt.Printf("%v login --url %v --user %v --initial --token %v --cert <<EOF \"%v\"\nEOF\n", AppName, Config.Url, Username, refreshToken, Config.Cert)
 
 			// Write the file is called after printing the output to handle avoid file write errors blocking user creation
 			if userConfigFilePath != "" {
@@ -79,7 +79,7 @@ var addCmd = &cobra.Command{
 					Url:      Config.Url,
 					Cert:     Config.Cert,
 					Username: Username,
-					Token:    token,
+					Token:    refreshToken,
 				}
 				writeConfigError := writeConfigToFile(userConfig, userConfigFilePath)
 				if writeConfigError != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -115,11 +115,11 @@ Example:
 				}
 			}
 			restClient := client.NewRestClient(Config.Url, Config.Token, Config.APIVersion, logging.Verbose, Config.Cert, &TokenStore)
-			token, err := restClient.Login(Username, Password)
+			refreshToken, _, err := restClient.Login(Username, Password)
 			if err != nil {
 				return err
 			}
-			Config.Token = token
+			Config.Token = refreshToken
 		}
 		Config.Username = Username
 		fmt.Println("Login Successful.")


### PR DESCRIPTION
Fix error when Kubist CLI `notificationservice` command report `bad handshake` error and exits after not being used for a while.

The problem was caused by using refresh token instead of access token after refresh token call.
Also it fixes a minor issue with selecting latest access token in `getAccessToken` function.