### PR TITLE
InitAppName should extract app name if path is used LAM-460

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -87,9 +88,15 @@ Application name is automacially set to the calling name
 */
 func InitAppName() string {
 	if len(os.Args) > 0 {
-		return os.Args[0]
+		return FilenameWithoutExtension(os.Args[0])
 	}
 	return "vamp"
+}
+
+// FilenameWithoutExtension extracts the last element without extension from path
+func FilenameWithoutExtension(fn string) string {
+	fn = path.Base(fn)
+	return strings.TrimSuffix(fn, path.Ext(fn))
 }
 
 // rootCmd represents the base command when called without any subcommands


### PR DESCRIPTION
As I understand Windows PowerShell expands the full path to the application automatically so initappname gets the full path to the application, not just the command used. So cleaning is needed.

.C:\Users\Username\bin\vamp.exe => vamp